### PR TITLE
Reward point slider

### DIFF
--- a/components/AssessmentMetadataFormSection.tsx
+++ b/components/AssessmentMetadataFormSection.tsx
@@ -95,7 +95,7 @@ export function AssessmentMetadataFormSection({
         </Select>
       </FormControl>
 
-      <Typography variant="caption" sx={{ marginTop: 2 }}>
+      <Typography variant="caption" sx={{ marginTop: 1 }}>
         Skill Points
       </Typography>
 

--- a/components/ContentMetadataFormSection.tsx
+++ b/components/ContentMetadataFormSection.tsx
@@ -1,4 +1,10 @@
-import { Autocomplete, Chip, Slider, TextField } from "@mui/material";
+import {
+  Autocomplete,
+  Chip,
+  Slider,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
@@ -69,6 +75,11 @@ export function ContentMetadataFormSection({
           },
         }}
       />
+
+      <Typography variant="caption" sx={{ marginTop: 1 }}>
+        Reward Points
+      </Typography>
+
       <Slider
         sx={{ marginX: 1 }}
         step={5}
@@ -83,6 +94,7 @@ export function ContentMetadataFormSection({
         value={rewardPoints}
         onChange={(e, a) => setRewardPoints(a as number)}
       />
+
       <Autocomplete
         multiple
         options={[]}

--- a/components/ContentMetadataFormSection.tsx
+++ b/components/ContentMetadataFormSection.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, Chip, TextField } from "@mui/material";
+import { Autocomplete, Chip, Slider, TextField } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
@@ -22,18 +22,14 @@ export function ContentMetadataFormSection({
   const [suggestedDate, setSuggestedDate] = useState(
     metadata ? dayjs(metadata.suggestedDate) : null
   );
-  const [rewardPointsStr, setRewardPointsStr] = useState(
-    metadata?.rewardPoints.toString() ?? "0"
-  );
   const [tags, setTags] = useState<string[]>([...(metadata?.tagNames ?? [])]);
 
-  const rewardPoints = parseInt(rewardPointsStr);
+  const [rewardPoints, setRewardPoints] = useState(metadata?.rewardPoints ?? 0);
 
   const valid =
     name.trim() != "" &&
     suggestedDate != null &&
     suggestedDate.isValid() &&
-    rewardPoints.toString() === rewardPointsStr &&
     rewardPoints >= 0;
 
   useEffect(() => {
@@ -47,15 +43,7 @@ export function ContentMetadataFormSection({
           }
         : null
     );
-  }, [
-    name,
-    suggestedDate,
-    rewardPointsStr,
-    tags,
-    rewardPoints,
-    valid,
-    onChange,
-  ]);
+  }, [name, suggestedDate, tags, rewardPoints, valid, onChange]);
 
   return (
     <FormSection title="Content details">
@@ -81,25 +69,20 @@ export function ContentMetadataFormSection({
           },
         }}
       />
-      <TextField
-        className="w-96"
-        label="Reward Points"
-        variant="outlined"
-        type="number"
-        value={rewardPointsStr}
-        error={
-          (!(metadata == null && rewardPointsStr.trim() == "") &&
-            rewardPoints.toString() !== rewardPointsStr) ||
-          (rewardPoints ?? 0) < 0
-        }
-        helperText={
-          (rewardPoints ?? 0) < 0 ? "Please enter a positive value" : undefined
-        }
-        onChange={(e) => setRewardPointsStr(e.target.value)}
-        multiline
-        required
+      <Slider
+        sx={{ marginX: 1 }}
+        step={5}
+        marks={[
+          { value: 10, label: "Low" },
+          { value: 50, label: "Medium" },
+          { value: 90, label: "High" },
+        ]}
+        min={0}
+        max={100}
+        valueLabelDisplay="auto"
+        value={rewardPoints}
+        onChange={(e, a) => setRewardPoints(a as number)}
       />
-
       <Autocomplete
         multiple
         options={[]}

--- a/components/QuizModal.tsx
+++ b/components/QuizModal.tsx
@@ -274,7 +274,7 @@ export function QuizModal({
                 if (val >= 1) {
                   setInput({
                     ...input,
-                    requiredCorrectAnswers: Number(e.target.value),
+                    requiredCorrectAnswers: val,
                   });
                 }
               }}

--- a/components/QuizModal.tsx
+++ b/components/QuizModal.tsx
@@ -269,12 +269,16 @@ export function QuizModal({
           <FormSection title="Scoring">
             <TextField
               value={input.requiredCorrectAnswers}
-              onChange={(e) =>
-                setInput({
-                  ...input,
-                  requiredCorrectAnswers: Number(e.target.value),
-                })
-              }
+              onChange={(e) => {
+                const val = Number(e.target.value);
+                if (val >= 1) {
+                  setInput({
+                    ...input,
+                    requiredCorrectAnswers: Number(e.target.value),
+                  });
+                }
+              }}
+              error={(input.requiredCorrectAnswers ?? 0) < 0}
               className="w-96"
               label="Required correct answers"
               variant="outlined"
@@ -301,15 +305,19 @@ export function QuizModal({
             {input.questionPoolingMode === "RANDOM" && (
               <TextField
                 value={input.numberOfRandomlySelectedQuestions}
-                onChange={(e) =>
-                  setInput({
-                    ...input,
-                    numberOfRandomlySelectedQuestions: Number(e.target.value),
-                  })
-                }
+                onChange={(e) => {
+                  const val = Number(e.target.value);
+                  if (val >= 1) {
+                    setInput({
+                      ...input,
+                      numberOfRandomlySelectedQuestions: val,
+                    });
+                  }
+                }}
                 className="w-96"
                 label="Number of randomly selected questions"
                 variant="outlined"
+                error={Number(input.numberOfRandomlySelectedQuestions ?? 0) < 0}
                 required
                 type="number"
               />

--- a/components/QuizModal.tsx
+++ b/components/QuizModal.tsx
@@ -162,7 +162,12 @@ export function QuizModal({
 
   const [error, setError] = useState<any>(null);
 
-  const valid = metadata && assessmentMetadata;
+  const valid =
+    metadata &&
+    assessmentMetadata &&
+    input.requiredCorrectAnswers > 0 &&
+    (input.questionPoolingMode !== "RANDOM" ||
+      (input.numberOfRandomlySelectedQuestions ?? 0) > 0);
 
   function onClose() {
     setInput(
@@ -195,7 +200,7 @@ export function QuizModal({
           },
           contentId: assessment!.id!,
           numberOfRandomlySelectedQuestions:
-            input.numberOfRandomlySelectedQuestions!,
+            input.numberOfRandomlySelectedQuestions ?? 1,
           questionPoolingMode: input.questionPoolingMode!,
           requiredCorrectAnswers: input.requiredCorrectAnswers!,
         },
@@ -269,16 +274,18 @@ export function QuizModal({
           <FormSection title="Scoring">
             <TextField
               value={input.requiredCorrectAnswers}
-              onChange={(e) => {
-                const val = Number(e.target.value);
-                if (val >= 1) {
-                  setInput({
-                    ...input,
-                    requiredCorrectAnswers: val,
-                  });
-                }
-              }}
-              error={(input.requiredCorrectAnswers ?? 0) < 0}
+              onChange={(e) =>
+                setInput({
+                  ...input,
+                  requiredCorrectAnswers: Number(e.target.value),
+                })
+              }
+              error={input.requiredCorrectAnswers <= 0}
+              helperText={
+                input.requiredCorrectAnswers <= 0
+                  ? "Must be greater than 0"
+                  : undefined
+              }
               className="w-96"
               label="Required correct answers"
               variant="outlined"
@@ -305,19 +312,21 @@ export function QuizModal({
             {input.questionPoolingMode === "RANDOM" && (
               <TextField
                 value={input.numberOfRandomlySelectedQuestions}
-                onChange={(e) => {
-                  const val = Number(e.target.value);
-                  if (val >= 1) {
-                    setInput({
-                      ...input,
-                      numberOfRandomlySelectedQuestions: val,
-                    });
-                  }
-                }}
+                onChange={(e) =>
+                  setInput({
+                    ...input,
+                    numberOfRandomlySelectedQuestions: Number(e.target.value),
+                  })
+                }
                 className="w-96"
                 label="Number of randomly selected questions"
                 variant="outlined"
-                error={Number(input.numberOfRandomlySelectedQuestions ?? 0) < 0}
+                error={(input.numberOfRandomlySelectedQuestions ?? 0) <= 0}
+                helperText={
+                  input.requiredCorrectAnswers <= 0
+                    ? "Must be greater than 0"
+                    : undefined
+                }
                 required
                 type="number"
               />

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -5,94 +5,37 @@ directive @specifiedBy(
 ) on SCALAR
 
 #  see also https://github.com/graphql-java/graphql-java-extended-validation/blob/master/README.md
-directive @DecimalMax(
-  value: String!
-  inclusive: Boolean! = true
-  message: String = "graphql.validation.DecimalMax.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @DecimalMax(value: String!, inclusive: Boolean! = true, message: String = "graphql.validation.DecimalMax.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @DecimalMin(
-  value: String!
-  inclusive: Boolean! = true
-  message: String = "graphql.validation.DecimalMin.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @DecimalMin(value: String!, inclusive: Boolean! = true, message: String = "graphql.validation.DecimalMin.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Max(
-  value: Int! = 2147483647
-  message: String = "graphql.validation.Max.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Max(value: Int! = 2147483647, message: String = "graphql.validation.Max.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Min(
-  value: Int! = 0
-  message: String = "graphql.validation.Min.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Min(value: Int! = 0, message: String = "graphql.validation.Min.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Negative(
-  message: String = "graphql.validation.Negative.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Negative(message: String = "graphql.validation.Negative.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @NegativeOrZero(
-  message: String = "graphql.validation.NegativeOrZero.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @NegativeOrZero(message: String = "graphql.validation.NegativeOrZero.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @NotBlank(
-  message: String = "graphql.validation.NotBlank.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @NotBlank(message: String = "graphql.validation.NotBlank.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @NotEmpty(
-  message: String = "graphql.validation.NotEmpty.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @NotEmpty(message: String = "graphql.validation.NotEmpty.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @ContainerNotEmpty(
-  message: String = "graphql.validation.ContainerNotEmpty.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @ContainerNotEmpty(message: String = "graphql.validation.ContainerNotEmpty.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Pattern(
-  regexp: String! = ".*"
-  message: String = "graphql.validation.Pattern.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Pattern(regexp: String! = ".*", message: String = "graphql.validation.Pattern.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Positive(
-  message: String = "graphql.validation.Positive.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Positive(message: String = "graphql.validation.Positive.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @PositiveOrZero(
-  message: String = "graphql.validation.PositiveOrZero.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @PositiveOrZero(message: String = "graphql.validation.PositiveOrZero.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Range(
-  min: Int = 0
-  max: Int = 2147483647
-  message: String = "graphql.validation.Range.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Range(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.Range.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Size(
-  min: Int = 0
-  max: Int = 2147483647
-  message: String = "graphql.validation.Size.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Size(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.Size.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @ContainerSize(
-  min: Int = 0
-  max: Int = 2147483647
-  message: String = "graphql.validation.ContainerSize.message"
-) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @ContainerSize(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.ContainerSize.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @resolveTo(
-  requiredSelectionSet: String
-  sourceName: String!
-  sourceTypeName: String!
-  sourceFieldName: String!
-  sourceSelectionSet: String
-  sourceArgs: ResolveToSourceArgs
-  keyField: String
-  keysArg: String
-  pubsubTopic: String
-  filterBy: String
-  additionalArgs: ResolveToSourceArgs
-  result: String
-  resultType: String
-) on FIELD_DEFINITION
+directive @resolveTo(requiredSelectionSet: String, sourceName: String!, sourceTypeName: String!, sourceFieldName: String!, sourceSelectionSet: String, sourceArgs: ResolveToSourceArgs, keyField: String, keysArg: String, pubsubTopic: String, filterBy: String, additionalArgs: ResolveToSourceArgs, result: String, resultType: String) on FIELD_DEFINITION
 
 interface Assessment {
   # Assessment metadata
@@ -426,6 +369,7 @@ type Course {
   yearDivision: YearDivision
 
   # Chapters of the course. Can be filtered and sorted.
+  # 🔒 User needs to be enrolled in the course to access this field.
   chapters(
     filter: ChapterFilter
 
@@ -902,7 +846,7 @@ type FlashcardSetAssessment implements Assessment & Content {
   progressDataForUser(userId: UUID!): UserProgressData!
 
   # The FlashcardSet of the assessment.
-  flashcardSet: FlashcardSet!
+  flashcardSet: FlashcardSet
 }
 
 type FlashcardSetMutation {
@@ -1114,35 +1058,13 @@ type MultipleChoiceQuestion implements Question {
 # Mutations for the flashcard service. Provides mutations for creating, updating, and deleting flashcard as well as
 # creating and deleting flashcard sets. To update a flashcard set, update, delete, and create flashcards individually.
 type Mutation {
-  # Creates a new course with the given input and returns the created course.
-  createCourse(input: CreateCourseInput!): Course!
-
-  # Creates a new chapter with the given input and returns the created chapter.
-  # The course id must be a course id of an existing course.
-  createChapter(input: CreateChapterInput!): Chapter!
-
-  # Updates an existing course with the given input and returns the updated course.
-  # The course id must be a course id of an existing course.
-  updateCourse(input: UpdateCourseInput!): Course!
-
-  # Updates an existing chapter with the given input and returns the updated chapter.
-  # The chapter id must be a chapter id of an existing chapter.
-  updateChapter(input: UpdateChapterInput!): Chapter!
-
-  # Deletes an existing course, throws an error if no course with the given id exists.
-  deleteCourse(id: UUID!): UUID!
-
-  # Deletes an existing chapter, throws an error if no chapter with the given id exists.
-  deleteChapter(id: UUID!): UUID!
-
-  # registers a user to a course with a role
-  createMembership(input: CourseMembershipInput!): CourseMembership!
-
-  # updates the role of a user in a course
-  updateMembership(input: CourseMembershipInput!): CourseMembership!
-
-  # deletes user course link
-  deleteMembership(input: CourseMembershipInput!): CourseMembership!
+  # ONLY FOR TESTING PURPOSES. DO NOT USE IN FRONTEND. WILL BE REMOVED.
+  #
+  # Triggers the recalculation of the skill level of the user.
+  # This is done automatically at some time in the night.
+  #
+  # The purpose of this mutation is to allow testing of the skill level score and demonstrate the functionality.
+  recalculateLevels(chapterId: UUID!, userId: UUID!): SkillLevels! @deprecated(reason: "Only for testing purposes. Will be removed.")
 
   # Creates a new media record
   createMediaRecord(input: CreateMediaRecordInput!): MediaRecord!
@@ -1155,10 +1077,7 @@ type Mutation {
 
   # For a given MediaContent, sets the linked media records of it to the ones with the given UUIDs.
   # This means that for the content, all already linked media records are removed and replaced by the given ones.
-  setLinkedMediaRecordsForContent(
-    contentId: UUID!
-    mediaRecordIds: [UUID!]!
-  ): [MediaRecord!]!
+  setLinkedMediaRecordsForContent(contentId: UUID!, mediaRecordIds: [UUID!]!): [MediaRecord!]!
 
   # Logs that a media has been worked on by the current user.
   # See https://gits-enpro.readthedocs.io/en/latest/dev-manuals/gamification/userProgress.html
@@ -1169,31 +1088,26 @@ type Mutation {
   logMediaRecordWorkedOn(mediaRecordId: UUID!): MediaRecord!
 
   # Add the MediaRecords with the given UUIDS to the Course with the given UUID.
-  setMediaRecordsForCourse(
-    courseId: UUID!
-    mediaRecordIds: [UUID!]!
-  ): [MediaRecord!]!
+  setMediaRecordsForCourse(courseId: UUID!, mediaRecordIds: [UUID!]!): [MediaRecord!]!
+
+  # Modify Content
+  # 🔒 The user must have admin access to the course containing the section to perform this action.
+  mutateContent(contentId: UUID!): ContentMutation!
+
+  # Modify the section with the given id.
+  # 🔒 The user must have admin access to the course containing the section to perform this action.
+  mutateSection(sectionId: UUID!): SectionMutation!
 
   # Modify a quiz.
+  # 🔒 The user must be an admin the course the quiz is in to perform this action.
   mutateQuiz(assessmentId: UUID!): QuizMutation!
 
   # Delete a quiz.
-  deleteQuiz(assessmentId: UUID!): UUID!
-    @deprecated(
-      reason: "Only use if you specifically only want to delete the quiz and not the whole assessment. Otherwise, use deleteAssessment in contents service instead."
-    )
+  deleteQuiz(assessmentId: UUID!): UUID! @deprecated(reason: "Only use if you specifically only want to delete the quiz and not the whole assessment. Otherwise, use deleteAssessment in contents service instead.")
 
   # Log that a multiple choice quiz is completed.
+  # 🔒 The user must be enrolled in the course the quiz is in to perform this action.
   logQuizCompleted(input: QuizCompletedInput!): QuizCompletionFeedback!
-
-  # Modify Content
-  mutateContent(contentId: UUID!): ContentMutation!
-
-  # Create new Section
-  createSection(input: CreateSectionInput!): Section!
-
-  # Modify Sections
-  mutateSection(sectionId: UUID!): SectionMutation!
 
   # ONLY FOR TESTING PURPOSES. DO NOT USE IN FRONTEND. WILL BE REMOVED.
   #
@@ -1201,50 +1115,69 @@ type Mutation {
   # This is done automatically at some time in the night.
   #
   # The purpose of this mutation is to allow testing of the reward score and demonstrate the functionality.
-  recalculateScores(courseId: UUID!, userId: UUID!): RewardScores!
-    @deprecated(reason: "Only for testing purposes. Will be removed.")
+  recalculateScores(courseId: UUID!, userId: UUID!): RewardScores! @deprecated(reason: "Only for testing purposes. Will be removed.")
 
-  # ONLY FOR TESTING PURPOSES. DO NOT USE IN FRONTEND. WILL BE REMOVED.
-  #
-  # Triggers the recalculation of the skill level of the user.
-  # This is done automatically at some time in the night.
-  #
-  # The purpose of this mutation is to allow testing of the skill level score and demonstrate the functionality.
-  recalculateLevels(chapterId: UUID!, userId: UUID!): SkillLevels!
-    @deprecated(reason: "Only for testing purposes. Will be removed.")
+  # Creates a new course with the given input and returns the created course.
+  createCourse(input: CreateCourseInput!): Course!
+
+  # Creates a new chapter with the given input and returns the created chapter.
+  # The course id must be a course id of an existing course.
+  # 🔒 The user must be an admin in this course to perform this action.
+  createChapter(input: CreateChapterInput!): Chapter!
+
+  # Updates an existing course with the given input and returns the updated course.
+  # The course id must be a course id of an existing course.
+  # 🔒 The user must be an admin in this course to perform this action.
+  updateCourse(input: UpdateCourseInput!): Course!
+
+  # Updates an existing chapter with the given input and returns the updated chapter.
+  # The chapter id must be a chapter id of an existing chapter.
+  # 🔒 The user must be an admin in this course to perform this action.
+  updateChapter(input: UpdateChapterInput!): Chapter!
+
+  # Deletes an existing course, throws an error if no course with the given id exists.
+  # 🔒 The user must be an admin in this course to perform this action.
+  deleteCourse(id: UUID!): UUID!
+
+  # Deletes an existing chapter, throws an error if no chapter with the given id exists.
+  # 🔒 The user must be an admin in this course to perform this action.
+  deleteChapter(id: UUID!): UUID!
+
+  # Adds the specified user to the specified course with the specified role.
+  # 🔒 The calling user must be an admin in this course to perform this action.
+  createMembership(input: CourseMembershipInput!): CourseMembership!
+
+  # Updates a user's membership in a course with the given input.
+  # 🔒 The calling user must be an admin in this course to perform this action.
+  updateMembership(input: CourseMembershipInput!): CourseMembership!
+
+  # Removes the specified user's access to the specified course.
+  # 🔒 The calling user must be an admin in this course to perform this action.
+  deleteMembership(input: CourseMembershipInput!): CourseMembership!
 
   # Deletes a flashcard set. Throws an error if the flashcard set does not exist.
   # The contained flashcards are deleted as well.
-  deleteFlashcardSet(input: UUID!): UUID!
-    @deprecated(
-      reason: "Only for development, will be removed in production. Use deleteAssessment in contents service instead."
-    )
+  deleteFlashcardSet(input: UUID!): UUID! @deprecated(reason: "Only for development, will be removed in production. Use deleteAssessment in contents service instead.")
 
   # Modify a flashcard set.
+  # 🔒 The user must be an admin the course the flashcard set is in to perform this action.
   mutateFlashcardSet(assessmentId: UUID!): FlashcardSetMutation!
 
   # Logs that a user has learned a flashcard.
-  logFlashcardLearned(
-    input: LogFlashcardLearnedInput!
-  ): FlashcardLearnedFeedback!
+  # 🔒 The user must be enrolled in the course the flashcard set is in to perform this action.
+  logFlashcardLearned(input: LogFlashcardLearnedInput!): FlashcardLearnedFeedback!
 
   # Creates a new media content and links the given media records to it.
-  createMediaContentAndLinkRecords(
-    contentInput: CreateMediaContentInput!
-    mediaRecordIds: [UUID!]!
-  ): MediaContent!
+  createMediaContentAndLinkRecords(contentInput: CreateMediaContentInput!, mediaRecordIds: [UUID!]!): MediaContent!
 
   # Creates a new quiz assessment and a new, linked quiz with the given properties.
-  createQuizAssessment(
-    assessmentInput: CreateAssessmentInput!
-    quizInput: CreateQuizInput!
-  ): QuizAssessment!
+  createQuizAssessment(assessmentInput: CreateAssessmentInput!, quizInput: CreateQuizInput!): QuizAssessment!
 
   # Creates a new flashcard set assessment and a new, linked flashcard set with the given properties.
-  createFlashcardSetAssessment(
-    assessmentInput: CreateAssessmentInput!
-    flashcardSetInput: CreateFlashcardSetInput!
-  ): FlashcardSetAssessment
+  createFlashcardSetAssessment(assessmentInput: CreateAssessmentInput!, flashcardSetInput: CreateFlashcardSetInput!): FlashcardSetAssessment
+
+  # Creates a new section in a chapter.
+  createSection(input: CreateSectionInput!): Section!
 }
 
 type NumericQuestion implements Question {
@@ -1329,53 +1262,6 @@ type PublicUserInfo {
 }
 
 type Query {
-  # Get a list of courses. Can be filtered, sorted and paginated.
-  courses(
-    filter: CourseFilter
-
-    # The fields to sort by.
-    # Throws an error if no field with the given name exists.
-    sortBy: [String!]
-
-    # The sort direction for each field. If not specified, defaults to ASC.
-    sortDirection: [SortDirection!]! = [ASC]
-    pagination: Pagination
-  ): CoursePayload!
-
-  # Returns the courses with the given ids.
-  coursesByIds(ids: [UUID!]!): [Course!]!
-
-  # Returns the chapters with the given ids.
-  chaptersByIds(ids: [UUID!]!): [Chapter!]!
-
-  # Returns a set of Resource Objects for the given resource ids, containing a
-  # list of all course IDs for a resource and its availability in the course.
-  courseResourceAssociationsByIds(ids: [UUID!]!): [CourseResourceAssociation!]!
-
-  # Returns a set of Resource Objects for the given resource ids, containing a
-  # list of all course IDs for a resource and its availability in the course.
-  resourceById(ids: [UUID!]!): [CourseResourceAssociation!]!
-    @deprecated(reason: "Use courseResourceAssociationsByIds instead.")
-
-  # Get the list of chapters for a course. Can be filtered, sorted and paginated.
-  # Throws an error if the course does not exist.
-  # The default sort order is by chapter number.
-  chapters(
-    courseId: UUID!
-    filter: ChapterFilter
-
-    # The fields to sort by. The default sort order is by chapter number.
-    # Throws an error if no field with the given name exists.
-    sortBy: [String!]! = []
-
-    # The sort direction for each field. If not specified, defaults to ASC.
-    sortDirection: [SortDirection!]! = [ASC]
-    pagination: Pagination
-  ): ChapterPayload!
-
-  # Returns the list of courseMemberships for the specified User.
-  courseMembershipsByUserIds(userIds: [UUID!]!): [[CourseMembership!]!]!
-
   # Gets the publicly available information for a list of users with the specified IDs.
   # If a user does not exist, null is returned for that user.
   findPublicUserInfos(ids: [UUID!]!): [PublicUserInfo]!
@@ -1388,6 +1274,12 @@ type Query {
   # If a user does not exist, null is returned for that user.
   findUserInfos(ids: [UUID!]!): [UserInfo]!
 
+  # Get the skill levels of the current user for all skill types for a list of chapter ids.
+  userSkillLevelsByChapterIds(chapterIds: [UUID!]!): [SkillLevels!]!
+
+  # Get the skill levels of the specified user for all skill types for a list of chapter ids.
+  skillLevelsForUserByChapterIds(chapterIds: [UUID!]!, userId: UUID!): [SkillLevels!]!
+
   # Returns the media records with the given IDs. Throws an error if a MediaRecord corresponding to a given ID
   # cannot be found.
   mediaRecordsByIds(ids: [UUID!]!): [MediaRecord!]!
@@ -1397,10 +1289,7 @@ type Query {
   findMediaRecordsByIds(ids: [UUID!]!): [MediaRecord]!
 
   # Returns all media records of the system.
-  mediaRecords: [MediaRecord!]!
-    @deprecated(
-      reason: "In production there should probably be no way to get all media records of the system."
-    )
+  mediaRecords: [MediaRecord!]! @deprecated(reason: "In production there should probably be no way to get all media records of the system.")
 
   # Returns all media records which the current user created.
   userMediaRecords: [MediaRecord!]!
@@ -1412,36 +1301,31 @@ type Query {
   # Returns all media records for the given CourseIds
   mediaRecordsForCourses(courseIds: [UUID!]!): [[MediaRecord!]!]!
 
-  # Get quiz by assessment ID.
-  # If any of the assessment IDs are not found, the corresponding quiz will be null.
-  findQuizzesByAssessmentIds(assessmentIds: [UUID!]!): [Quiz]!
-
-  # Retrieves all existing contents.
-  contents: ContentPayload!
-    @deprecated(
-      reason: "Querying all contents will not be supported in the future. Use contentsByIds instead"
-    )
-
   # Retrieves all existing contents for a given course.
+  # 🔒 The user must have access to the courses with the given ids to access their contents, otherwise an error is thrown.
   contentsByCourseIds(courseIds: [UUID!]!): [[Content!]!]
 
   # Get contents by ids. Throws an error if any of the ids are not found.
+  # 🔒 The user must have access to the courses containing the contents with the given ids to access their contents,
+  # otherwise an error is thrown.
   contentsByIds(ids: [UUID!]!): [Content!]!
 
   # Get contents by ids. If any of the given ids are not found, the corresponding element in the result list will be null.
+  # 🔒 The user must have access to the courses containing the contents with the given ids, otherwise null is returned
+  # for the respective contents.
   findContentsByIds(ids: [UUID!]!): [Content]!
 
   # Get contents by chapter ids. Returns a list containing sublists, where each sublist contains all contents
   # associated with that chapter
+  # 🔒 The user must have access to the courses containing the chapters with the given ids, otherwise an error is thrown.
   contentsByChapterIds(chapterIds: [UUID!]!): [[Content!]!]!
-
-  # Retrieves all existing sections for multiple chapters.
-  sectionsByChapterIds(chapterIds: [UUID!]!): [[Section!]!]!
 
   # Generates user specific suggestions for multiple chapters.
   #
   # Only content that the user can access will be considered.
   # The contents will be ranked by suggested date, with the most overdue or most urgent content first.
+  #
+  # 🔒 The user must have access to the courses containing the chapters with the given ids, otherwise an error is thrown.
   suggestionsByChapterIds(
     # The ids of the chapters for which suggestions should be generated.
     chapterIds: [UUID!]!
@@ -1455,6 +1339,12 @@ type Query {
     skillTypes: [SkillType!]! = []
   ): [Suggestion!]!
 
+  # Get quiz by assessment ID.
+  # If any of the assessment IDs are not found, the corresponding quiz will be null.
+  # 🔒 The user must be enrolled in the course the quizzes belong to to access them. Otherwise null is returned for
+  # an quiz if the user has no access to it.
+  findQuizzesByAssessmentIds(assessmentIds: [UUID!]!): [Quiz]!
+
   # Get the reward score of the current user for the specified course.
   userCourseRewardScores(courseId: UUID!): RewardScores!
 
@@ -1464,21 +1354,40 @@ type Query {
   # Gets the power scores for each user in the course, ordered by power score descending.
   scoreboard(courseId: UUID!): [ScoreboardItem!]!
 
-  # Get the skill levels of the current user for all skill types for a list of chapter ids.
-  userSkillLevelsByChapterIds(chapterIds: [UUID!]!): [SkillLevels!]!
+  # Get a list of courses. Can be filtered, sorted and paginated.
+  # Courses and their basic data can be queried by any user, even if they are not enrolled in the course.
+  courses(
+    filter: CourseFilter
 
-  # Get the skill levels of the specified user for all skill types for a list of chapter ids.
-  skillLevelsForUserByChapterIds(
-    chapterIds: [UUID!]!
-    userId: UUID!
-  ): [SkillLevels!]!
+    # The fields to sort by.
+    # Throws an error if no field with the given name exists.
+    sortBy: [String!]
 
-  # Get flashcards by their ids
+    # The sort direction for each field. If not specified, defaults to ASC.
+    sortDirection: [SortDirection!]! = [ASC]
+    pagination: Pagination
+  ): CoursePayload!
+
+  # Returns the courses with the given ids.
+  # Courses and their basic data can be queried by any user, even if they are not enrolled in the course.
+  coursesByIds(ids: [UUID!]!): [Course!]!
+
+  # Returns a set of Resource Objects for the given resource ids, containing a list of all course IDs for a resource
+  # and its availability in the course.
+  courseResourceAssociationsByIds(ids: [UUID!]!): [CourseResourceAssociation!]!
+
+  # Returns a set of Resource Objects for the given resource ids, containing a
+  # list of all course IDs for a resource and its availability in the course.
+  resourceById(ids: [UUID!]!): [CourseResourceAssociation!]! @deprecated(reason: "Use courseResourceAssociationsByIds instead.")
+
+  # Get flashcards by their ids.
+  # 🔒 The user must be enrolled in the course the flashcards belong to. Otherwise an error is thrown.
   flashcardsByIds(ids: [UUID!]!): [Flashcard!]!
 
   # Get flashcard sets by their assessment ids.
   # Returns a list of flashcard sets in the same order as the provided ids.
   # Each element is null if the corresponding id is not found.
+  # 🔒 The user must be enrolled in the course the flashcard sets belong to. Otherwise for that element null is returned.
   findFlashcardSetsByAssessmentIds(assessmentIds: [UUID!]!): [FlashcardSet]!
 }
 
@@ -1558,6 +1467,9 @@ type Quiz {
   # This will be different each time it is queried if questionPoolingMode is RANDOM.
   selectedQuestions: [Question!]!
 
+  # Id of the course this quiz belongs to.
+  courseId: UUID!
+
   # The content this quiz belongs to.
   content: Content
 }
@@ -1581,7 +1493,7 @@ type QuizAssessment implements Assessment & Content {
 
   # The quiz of the assessment.
   # If this is null the system is in an inconsistent state and the assessment should be deleted.
-  quiz: Quiz!
+  quiz: Quiz
 }
 
 input QuizCompletedInput {
@@ -1659,9 +1571,7 @@ type QuizMutation {
 
   # Set the number of questions that are randomly selected from the list of questions.
   # Will only be considered if questionPoolingMode is RANDOM.
-  setNumberOfRandomlySelectedQuestions(
-    numberOfRandomlySelectedQuestions: Int!
-  ): Quiz!
+  setNumberOfRandomlySelectedQuestions(numberOfRandomlySelectedQuestions: Int!): Quiz!
 }
 
 scalar ResolveToSourceArgs
@@ -1759,6 +1669,9 @@ type ScoreboardItem {
 type Section {
   # Unique identifier of the Section Object
   id: UUID!
+
+  # Id of the Course the Section is located in.
+  courseId: UUID!
 
   # Name of the Section
   name: String!
@@ -2047,6 +1960,12 @@ input UpdateCourseInput {
 
   # The new published status of the course.
   published: Boolean!
+
+  # The year in which the term starts.
+  startYear: Int
+
+  # The division of the academic calendar in which the term takes place.
+  yearDivision: YearDivision
 }
 
 input UpdateExactAnswerQuestionInput {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -5,37 +5,94 @@ directive @specifiedBy(
 ) on SCALAR
 
 #  see also https://github.com/graphql-java/graphql-java-extended-validation/blob/master/README.md
-directive @DecimalMax(value: String!, inclusive: Boolean! = true, message: String = "graphql.validation.DecimalMax.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @DecimalMax(
+  value: String!
+  inclusive: Boolean! = true
+  message: String = "graphql.validation.DecimalMax.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @DecimalMin(value: String!, inclusive: Boolean! = true, message: String = "graphql.validation.DecimalMin.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @DecimalMin(
+  value: String!
+  inclusive: Boolean! = true
+  message: String = "graphql.validation.DecimalMin.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Max(value: Int! = 2147483647, message: String = "graphql.validation.Max.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Max(
+  value: Int! = 2147483647
+  message: String = "graphql.validation.Max.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Min(value: Int! = 0, message: String = "graphql.validation.Min.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Min(
+  value: Int! = 0
+  message: String = "graphql.validation.Min.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Negative(message: String = "graphql.validation.Negative.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Negative(
+  message: String = "graphql.validation.Negative.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @NegativeOrZero(message: String = "graphql.validation.NegativeOrZero.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @NegativeOrZero(
+  message: String = "graphql.validation.NegativeOrZero.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @NotBlank(message: String = "graphql.validation.NotBlank.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @NotBlank(
+  message: String = "graphql.validation.NotBlank.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @NotEmpty(message: String = "graphql.validation.NotEmpty.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @NotEmpty(
+  message: String = "graphql.validation.NotEmpty.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @ContainerNotEmpty(message: String = "graphql.validation.ContainerNotEmpty.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @ContainerNotEmpty(
+  message: String = "graphql.validation.ContainerNotEmpty.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Pattern(regexp: String! = ".*", message: String = "graphql.validation.Pattern.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Pattern(
+  regexp: String! = ".*"
+  message: String = "graphql.validation.Pattern.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Positive(message: String = "graphql.validation.Positive.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Positive(
+  message: String = "graphql.validation.Positive.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @PositiveOrZero(message: String = "graphql.validation.PositiveOrZero.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @PositiveOrZero(
+  message: String = "graphql.validation.PositiveOrZero.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Range(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.Range.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Range(
+  min: Int = 0
+  max: Int = 2147483647
+  message: String = "graphql.validation.Range.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @Size(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.Size.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @Size(
+  min: Int = 0
+  max: Int = 2147483647
+  message: String = "graphql.validation.Size.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @ContainerSize(min: Int = 0, max: Int = 2147483647, message: String = "graphql.validation.ContainerSize.message") on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @ContainerSize(
+  min: Int = 0
+  max: Int = 2147483647
+  message: String = "graphql.validation.ContainerSize.message"
+) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @resolveTo(requiredSelectionSet: String, sourceName: String!, sourceTypeName: String!, sourceFieldName: String!, sourceSelectionSet: String, sourceArgs: ResolveToSourceArgs, keyField: String, keysArg: String, pubsubTopic: String, filterBy: String, additionalArgs: ResolveToSourceArgs, result: String, resultType: String) on FIELD_DEFINITION
+directive @resolveTo(
+  requiredSelectionSet: String
+  sourceName: String!
+  sourceTypeName: String!
+  sourceFieldName: String!
+  sourceSelectionSet: String
+  sourceArgs: ResolveToSourceArgs
+  keyField: String
+  keysArg: String
+  pubsubTopic: String
+  filterBy: String
+  additionalArgs: ResolveToSourceArgs
+  result: String
+  resultType: String
+) on FIELD_DEFINITION
 
 interface Assessment {
   # Assessment metadata
@@ -1064,7 +1121,8 @@ type Mutation {
   # This is done automatically at some time in the night.
   #
   # The purpose of this mutation is to allow testing of the skill level score and demonstrate the functionality.
-  recalculateLevels(chapterId: UUID!, userId: UUID!): SkillLevels! @deprecated(reason: "Only for testing purposes. Will be removed.")
+  recalculateLevels(chapterId: UUID!, userId: UUID!): SkillLevels!
+    @deprecated(reason: "Only for testing purposes. Will be removed.")
 
   # Creates a new media record
   createMediaRecord(input: CreateMediaRecordInput!): MediaRecord!
@@ -1077,7 +1135,10 @@ type Mutation {
 
   # For a given MediaContent, sets the linked media records of it to the ones with the given UUIDs.
   # This means that for the content, all already linked media records are removed and replaced by the given ones.
-  setLinkedMediaRecordsForContent(contentId: UUID!, mediaRecordIds: [UUID!]!): [MediaRecord!]!
+  setLinkedMediaRecordsForContent(
+    contentId: UUID!
+    mediaRecordIds: [UUID!]!
+  ): [MediaRecord!]!
 
   # Logs that a media has been worked on by the current user.
   # See https://gits-enpro.readthedocs.io/en/latest/dev-manuals/gamification/userProgress.html
@@ -1088,7 +1149,10 @@ type Mutation {
   logMediaRecordWorkedOn(mediaRecordId: UUID!): MediaRecord!
 
   # Add the MediaRecords with the given UUIDS to the Course with the given UUID.
-  setMediaRecordsForCourse(courseId: UUID!, mediaRecordIds: [UUID!]!): [MediaRecord!]!
+  setMediaRecordsForCourse(
+    courseId: UUID!
+    mediaRecordIds: [UUID!]!
+  ): [MediaRecord!]!
 
   # Modify Content
   # 🔒 The user must have admin access to the course containing the section to perform this action.
@@ -1103,7 +1167,10 @@ type Mutation {
   mutateQuiz(assessmentId: UUID!): QuizMutation!
 
   # Delete a quiz.
-  deleteQuiz(assessmentId: UUID!): UUID! @deprecated(reason: "Only use if you specifically only want to delete the quiz and not the whole assessment. Otherwise, use deleteAssessment in contents service instead.")
+  deleteQuiz(assessmentId: UUID!): UUID!
+    @deprecated(
+      reason: "Only use if you specifically only want to delete the quiz and not the whole assessment. Otherwise, use deleteAssessment in contents service instead."
+    )
 
   # Log that a multiple choice quiz is completed.
   # 🔒 The user must be enrolled in the course the quiz is in to perform this action.
@@ -1115,7 +1182,8 @@ type Mutation {
   # This is done automatically at some time in the night.
   #
   # The purpose of this mutation is to allow testing of the reward score and demonstrate the functionality.
-  recalculateScores(courseId: UUID!, userId: UUID!): RewardScores! @deprecated(reason: "Only for testing purposes. Will be removed.")
+  recalculateScores(courseId: UUID!, userId: UUID!): RewardScores!
+    @deprecated(reason: "Only for testing purposes. Will be removed.")
 
   # Creates a new course with the given input and returns the created course.
   createCourse(input: CreateCourseInput!): Course!
@@ -1157,7 +1225,10 @@ type Mutation {
 
   # Deletes a flashcard set. Throws an error if the flashcard set does not exist.
   # The contained flashcards are deleted as well.
-  deleteFlashcardSet(input: UUID!): UUID! @deprecated(reason: "Only for development, will be removed in production. Use deleteAssessment in contents service instead.")
+  deleteFlashcardSet(input: UUID!): UUID!
+    @deprecated(
+      reason: "Only for development, will be removed in production. Use deleteAssessment in contents service instead."
+    )
 
   # Modify a flashcard set.
   # 🔒 The user must be an admin the course the flashcard set is in to perform this action.
@@ -1165,16 +1236,27 @@ type Mutation {
 
   # Logs that a user has learned a flashcard.
   # 🔒 The user must be enrolled in the course the flashcard set is in to perform this action.
-  logFlashcardLearned(input: LogFlashcardLearnedInput!): FlashcardLearnedFeedback!
+  logFlashcardLearned(
+    input: LogFlashcardLearnedInput!
+  ): FlashcardLearnedFeedback!
 
   # Creates a new media content and links the given media records to it.
-  createMediaContentAndLinkRecords(contentInput: CreateMediaContentInput!, mediaRecordIds: [UUID!]!): MediaContent!
+  createMediaContentAndLinkRecords(
+    contentInput: CreateMediaContentInput!
+    mediaRecordIds: [UUID!]!
+  ): MediaContent!
 
   # Creates a new quiz assessment and a new, linked quiz with the given properties.
-  createQuizAssessment(assessmentInput: CreateAssessmentInput!, quizInput: CreateQuizInput!): QuizAssessment!
+  createQuizAssessment(
+    assessmentInput: CreateAssessmentInput!
+    quizInput: CreateQuizInput!
+  ): QuizAssessment!
 
   # Creates a new flashcard set assessment and a new, linked flashcard set with the given properties.
-  createFlashcardSetAssessment(assessmentInput: CreateAssessmentInput!, flashcardSetInput: CreateFlashcardSetInput!): FlashcardSetAssessment
+  createFlashcardSetAssessment(
+    assessmentInput: CreateAssessmentInput!
+    flashcardSetInput: CreateFlashcardSetInput!
+  ): FlashcardSetAssessment
 
   # Creates a new section in a chapter.
   createSection(input: CreateSectionInput!): Section!
@@ -1278,7 +1360,10 @@ type Query {
   userSkillLevelsByChapterIds(chapterIds: [UUID!]!): [SkillLevels!]!
 
   # Get the skill levels of the specified user for all skill types for a list of chapter ids.
-  skillLevelsForUserByChapterIds(chapterIds: [UUID!]!, userId: UUID!): [SkillLevels!]!
+  skillLevelsForUserByChapterIds(
+    chapterIds: [UUID!]!
+    userId: UUID!
+  ): [SkillLevels!]!
 
   # Returns the media records with the given IDs. Throws an error if a MediaRecord corresponding to a given ID
   # cannot be found.
@@ -1289,7 +1374,10 @@ type Query {
   findMediaRecordsByIds(ids: [UUID!]!): [MediaRecord]!
 
   # Returns all media records of the system.
-  mediaRecords: [MediaRecord!]! @deprecated(reason: "In production there should probably be no way to get all media records of the system.")
+  mediaRecords: [MediaRecord!]!
+    @deprecated(
+      reason: "In production there should probably be no way to get all media records of the system."
+    )
 
   # Returns all media records which the current user created.
   userMediaRecords: [MediaRecord!]!
@@ -1378,7 +1466,8 @@ type Query {
 
   # Returns a set of Resource Objects for the given resource ids, containing a
   # list of all course IDs for a resource and its availability in the course.
-  resourceById(ids: [UUID!]!): [CourseResourceAssociation!]! @deprecated(reason: "Use courseResourceAssociationsByIds instead.")
+  resourceById(ids: [UUID!]!): [CourseResourceAssociation!]!
+    @deprecated(reason: "Use courseResourceAssociationsByIds instead.")
 
   # Get flashcards by their ids.
   # 🔒 The user must be enrolled in the course the flashcards belong to. Otherwise an error is thrown.
@@ -1571,7 +1660,9 @@ type QuizMutation {
 
   # Set the number of questions that are randomly selected from the list of questions.
   # Will only be considered if questionPoolingMode is RANDOM.
-  setNumberOfRandomlySelectedQuestions(numberOfRandomlySelectedQuestions: Int!): Quiz!
+  setNumberOfRandomlySelectedQuestions(
+    numberOfRandomlySelectedQuestions: Int!
+  ): Quiz!
 }
 
 scalar ResolveToSourceArgs


### PR DESCRIPTION
# Description of changes

closes #127 
+ make the quiz assesment input for the number of required correct answers and question pooling positive, to avoid a nullpointer exception in the backend

## How has this been tested?

Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test

In case of manual test, please document the test well including a set of user instructions and prerequisites. Each including an action, it's result, and where appropriate a screenshot.

## Checklist before requesting a review

- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfilles all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer

- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
